### PR TITLE
fix typo of dns test cases

### DIFF
--- a/dns/dns_test.go
+++ b/dns/dns_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestLookupShoudFailWithBadNS(t *testing.T) {
+func TestLookupShouldFailWithBadNS(t *testing.T) {
 	lib := NewLookupLib("foo:9999")
 
 	_, err := lib.LookupA("foo")
@@ -16,7 +16,7 @@ func TestLookupShoudFailWithBadNS(t *testing.T) {
 	assert.NotNil(t, err)
 }
 
-func TestLookupShoudFailWithBadHost(t *testing.T) {
+func TestLookupShouldFailWithBadHost(t *testing.T) {
 	lib := NewLookupLib("8.8.8.8:53")
 
 	_, err := lib.LookupA("foo")


### PR DESCRIPTION
`srv-lb` is cool and I just read some of the source code then found some typos.
