### PR TITLE
Improve resolv.conf handling

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,8 @@ language: go
 go:
   - 1.4
   - 1.5
+  - 1.6
+  - 1.7
   - tip
 
 

--- a/README.md
+++ b/README.md
@@ -30,7 +30,12 @@ The library defaults to use a "Round Robin" algorithm, but you can specify anoth
 ### Default Load Balancer
 
 	srvName := "foo.service.fligl.io"
-	l := lb.New(lb.DefaultConfig(), srvName)
+	cfg, err := lb.DefaultConfig()
+	if err != nil {
+		panic(err)
+	}
+
+	l := lb.New(cfg, srvName)
 
 	address, err := l.Next()
 	if err != nil {
@@ -47,7 +52,12 @@ The library defaults to use a "Round Robin" algorithm, but you can specify anoth
 ### or build a generic load balancer
 
 	srvName := "foo.service.fligl.io"
-	l := lb.NewGeneric(lb.DefaultConfig())
+	cfg, err := lb.DefaultConfig()
+	if err != nil {
+		panic(err)
+	}
+
+	l := lb.NewGeneric(cfg)
 
 	address, err := l.Next(srvName)
 	if err != nil {
@@ -114,7 +124,7 @@ Register it with the load balancer
 
 And then specify it when constructing your load balancer
 
-	cfg := lb.DefaultConfig()
+	cfg, _ := lb.DefaultConfig()
 	cfg.Strategy = fancy.FancyStrategy
 	
 	l := lb.New(cfg, srvName)

--- a/dns/dns_test.go
+++ b/dns/dns_test.go
@@ -36,7 +36,8 @@ func TestLookupShouldResolveARecord(t *testing.T) {
 }
 
 func TestDefaultLookupA(t *testing.T) {
-	lib := NewDefaultLookupLib()
+	lib, err := NewDefaultLookupLib()
+	assert.Nil(t, err)
 
 	address, err := lib.LookupA("github.com")
 
@@ -47,7 +48,8 @@ func TestDefaultLookupA(t *testing.T) {
 }
 
 func TestDefaultLookupSRV(t *testing.T) {
-	lib := NewDefaultLookupLib()
+	lib, err := NewDefaultLookupLib()
+	assert.Nil(t, err)
 
 	addresses, err := lib.LookupSRV("foo.service.fligl.io")
 

--- a/dns/dns_test.go
+++ b/dns/dns_test.go
@@ -63,11 +63,33 @@ func TestDefaultLookupSRV(t *testing.T) {
 	assert.Equal(t, "foo2.fligl.io.", addresses[1].Target, "Unexpected Result")
 }
 
+func TestLookUpShouldSkipBadNS(t *testing.T) {
+	lib, err := NewClientConfigLookupLib(&firstNSBadClientConfig{})
+
+	assert.Nil(t, err)
+
+	address, err := lib.LookupA("github.com")
+
+	assert.Nil(t, err)
+
+	ip := net.ParseIP(address)
+	assert.NotNil(t, ip.To4())
+}
+
 type predictableClientConfig struct{}
 
 func (c *predictableClientConfig) Get() (*dns.ClientConfig, error) {
 	return &dns.ClientConfig{
 		Servers: []string{"8.8.8.8", "8.8.4.4"},
+		Port:    "53",
+	}, nil
+}
+
+type firstNSBadClientConfig struct{}
+
+func (c *firstNSBadClientConfig) Get() (*dns.ClientConfig, error) {
+	return &dns.ClientConfig{
+		Servers: []string{"foo", "8.8.8.8"},
 		Port:    "53",
 	}, nil
 }

--- a/dns/dns_test.go
+++ b/dns/dns_test.go
@@ -5,6 +5,7 @@ import (
 	"sort"
 	"testing"
 
+	"github.com/miekg/dns"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -35,8 +36,8 @@ func TestLookupShouldResolveARecord(t *testing.T) {
 	assert.NotNil(t, ip.To4())
 }
 
-func TestDefaultLookupA(t *testing.T) {
-	lib, err := NewDefaultLookupLib()
+func TestClientConfigLookupA(t *testing.T) {
+	lib, err := NewClientConfigLookupLib(&predictableClientConfig{})
 	assert.Nil(t, err)
 
 	address, err := lib.LookupA("github.com")
@@ -48,7 +49,7 @@ func TestDefaultLookupA(t *testing.T) {
 }
 
 func TestDefaultLookupSRV(t *testing.T) {
-	lib, err := NewDefaultLookupLib()
+	lib, err := NewClientConfigLookupLib(&predictableClientConfig{})
 	assert.Nil(t, err)
 
 	addresses, err := lib.LookupSRV("foo.service.fligl.io")
@@ -60,4 +61,13 @@ func TestDefaultLookupSRV(t *testing.T) {
 	assert.Equal(t, 2, len(addresses), "should be two results")
 	assert.Equal(t, "foo1.fligl.io.", addresses[0].Target, "Unexpected Result")
 	assert.Equal(t, "foo2.fligl.io.", addresses[1].Target, "Unexpected Result")
+}
+
+type predictableClientConfig struct{}
+
+func (c *predictableClientConfig) Get() (*dns.ClientConfig, error) {
+	return &dns.ClientConfig{
+		Servers: []string{"8.8.8.8", "8.8.4.4"},
+		Port:    "53",
+	}, nil
 }

--- a/dns/lib.go
+++ b/dns/lib.go
@@ -12,12 +12,15 @@ type Lookup interface {
 	LookupA(name string) (string, error)
 }
 
-func NewDefaultLookupLib() Lookup {
-	config, _ := dns.ClientConfigFromFile("/etc/resolv.conf")
+func NewDefaultLookupLib() (Lookup, error) {
+	config, err := dns.ClientConfigFromFile("/etc/resolv.conf")
+	if err != nil {
+		return nil, err
+	}
 	serverString := config.Servers[0] + ":" + config.Port
 	l := new(lookupLib)
 	l.serverString = serverString
-	return l
+	return l, nil
 }
 func NewLookupLib(serverString string) Lookup {
 	l := new(lookupLib)

--- a/dns/lib.go
+++ b/dns/lib.go
@@ -12,8 +12,24 @@ type Lookup interface {
 	LookupA(name string) (string, error)
 }
 
+type ClientConfig interface {
+	Get() (*dns.ClientConfig, error)
+}
+
+type ResolvConfClientConfig struct {
+	File string
+}
+
+func (f *ResolvConfClientConfig) Get() (*dns.ClientConfig, error) {
+	return dns.ClientConfigFromFile(f.File)
+}
+
 func NewDefaultLookupLib() (Lookup, error) {
-	config, err := dns.ClientConfigFromFile("/etc/resolv.conf")
+	return NewClientConfigLookupLib(&ResolvConfClientConfig{"/etc/resolv.conf"})
+}
+
+func NewClientConfigLookupLib(cfg ClientConfig) (Lookup, error) {
+	config, err := cfg.Get()
 	if err != nil {
 		return nil, err
 	}
@@ -22,6 +38,7 @@ func NewDefaultLookupLib() (Lookup, error) {
 	l.serverString = serverString
 	return l, nil
 }
+
 func NewLookupLib(serverString string) Lookup {
 	l := new(lookupLib)
 	l.serverString = serverString

--- a/lb/config.go
+++ b/lb/config.go
@@ -11,17 +11,21 @@ type Config struct {
 	Strategy StrategyType
 }
 
-func DefaultConfig() *Config {
+func DefaultConfig() (*Config, error) {
 	var dnsLib dns.Lookup
 
 	if dnsHost := os.Getenv("SRVLB_HOST"); dnsHost != "" {
 		dnsLib = dns.NewLookupLib(dnsHost)
 	} else {
-		dnsLib = dns.NewDefaultLookupLib()
+		lib, err := dns.NewDefaultLookupLib()
+		if err != nil {
+			return nil, err
+		}
+		dnsLib = lib
 	}
 
 	return &Config{
 		Dns:      dnsLib,
 		Strategy: RoundRobinStrategy,
-	}
+	}, nil
 }

--- a/lb/lb_test.go
+++ b/lb/lb_test.go
@@ -20,7 +20,11 @@ func (a ByConnectionString) Less(i, j int) bool {
 
 // Example load balancer with defaults
 func ExampleNew() {
-	lb := New(DefaultConfig(), "foo.service.fligl.io")
+	cfg, err := DefaultConfig()
+	if err != nil {
+		panic(err)
+	}
+	lb := New(cfg, "foo.service.fligl.io")
 
 	add1, err := lb.Next()
 	if err != nil {
@@ -43,7 +47,11 @@ func ExampleNew() {
 // Example of using a generic load balancer
 func ExampleNewGeneric() {
 	srvName := "foo.service.fligl.io"
-	lb := NewGeneric(DefaultConfig())
+	cfg, err := DefaultConfig()
+	if err != nil {
+		panic(err)
+	}
+	lb := NewGeneric(cfg)
 
 	add1, err := lb.Next(srvName)
 	if err != nil {

--- a/lb/roundrobin_test.go
+++ b/lb/roundrobin_test.go
@@ -13,9 +13,11 @@ var _ = fmt.Print // For debugging; delete when done.
 var _ = log.Print // For debugging; delete when done.
 
 func TestRoundRobinLookup(t *testing.T) {
+	lib, err := dns.NewDefaultLookupLib()
+	assert.Nil(t, err)
+
 	// given
 	srvName := "foo.service.fligl.io"
-	lib := dns.NewDefaultLookupLib()
 	c := NewRoundRobinStrategy(lib)
 
 	// when

--- a/strategy/random/random_test.go
+++ b/strategy/random/random_test.go
@@ -14,9 +14,11 @@ var _ = log.Print // For debugging; delete when done.
 
 //strconv.FormatInt(int64(srv.Port), 10)
 func TestRandomLookup(t *testing.T) {
+	lib, err := dns.NewDefaultLookupLib()
+	assert.Nil(t, err)
+
 	// given
 	srvName := "foo.service.fligl.io"
-	lib := dns.NewDefaultLookupLib()
 	c := New(lib)
 
 	// when

--- a/strategy_test.go
+++ b/strategy_test.go
@@ -22,9 +22,12 @@ func (a ByConnectionString) Less(i, j int) bool {
 }
 
 func TestRoundRobinStrategy(t *testing.T) {
+	lib, err := dns.NewDefaultLookupLib()
+	assert.Nil(t, err)
+
 	//given
 	c := lb.NewGeneric(&lb.Config{
-		Dns:      dns.NewDefaultLookupLib(),
+		Dns:      lib,
 		Strategy: lb.RoundRobinStrategy,
 	})
 
@@ -45,15 +48,18 @@ func TestRoundRobinStrategy(t *testing.T) {
 }
 
 func TestRandomStrategy(t *testing.T) {
+	lib, err := dns.NewDefaultLookupLib()
+	assert.Nil(t, err)
+
 	//given
 	c := lb.NewGeneric(&lb.Config{
-		Dns:      dns.NewDefaultLookupLib(),
+		Dns:      lib,
 		Strategy: random.RandomStrategy,
 	})
 
 	// when
 	srvName := "foo.service.fligl.io"
-	_, err := c.Next(srvName)
+	_, err = c.Next(srvName)
 
 	// then
 	assert.Nil(t, err)


### PR DESCRIPTION
Thanks for this great little library! As a heavy user of SRV records it's nice to not have to reinvent the wheel.

This PR addresses https://github.com/benschw/srv-lb/issues/2, and thus slightly alters the API:
- `DefaultConfig()` now returns `(*Config, error)`
- `NewDefaultLookupLib()` now returns `(Lookup, error)`.

It also adds a few niceties around `resolv.conf`, namely:
- The lookup libs will now lookup records against all nameservers in a parsed `resolv.conf` sequentially. The first successful result will be returned. If all nameservers fail the last error will be returned.
- Wraps the call to `dns.ClientConfigFromFile()` in an interface so tests don't have to parse a real `resolv.conf`
